### PR TITLE
Add auth_options resolution from config

### DIFF
--- a/src/pywrapid/webclient/web.py
+++ b/src/pywrapid/webclient/web.py
@@ -534,7 +534,8 @@ class WebClient:  # pylint: disable=too-many-instance-attributes, too-many-argum
             Response: requests.Response object
         """
         if not skip_authentication and self.session_expired():
-            self.generate_session(**self._credential_options)
+            login_options = {**self._credential_options, **self._config.get("auth_options", {})}
+            self.generate_session(**login_options)
 
         if self._access_token and self._authorization_type != AuthorizationType.NONE:
             if "headers" not in options:


### PR DESCRIPTION
New feature to allow passing different client options while authenticating.
Previously only allowed client_options to be raw passed to the wrapped package. There are occations when for example an auth service resides on the internet and the web service resides in an internal network, where it is needed to only use proxy for the auth but not the call.

We now introduced "auth_options" configuration to allow the same methodology of passing raw options to the wrapped client independently.

Enjoy.